### PR TITLE
Add user missions

### DIFF
--- a/src/components/missions/missions.js
+++ b/src/components/missions/missions.js
@@ -11,7 +11,7 @@ const MissionLi = ({
     dispatch(joinMissionAction(id));
   };
 
-  const changeContentStatus = (bool) => (bool ? 'member' : 'not a member');
+  const changeContentStatus = (bool) => (bool ? 'active member' : 'not a member');
 
   return (
     <li className="mission-li">

--- a/src/components/user/user-missions.css
+++ b/src/components/user/user-missions.css
@@ -1,0 +1,17 @@
+.user-missions-ul {
+  display: flex;
+  flex-wrap: wrap;
+  width: 45%;
+}
+.user-missions-title {
+  font-size: 1.5em;
+  font-weight: 600;
+  flex: 1 100%;
+  margin-bottom: 10px;
+}
+
+.user-missions-li {
+  flex: 1 100%;
+  border: 1px solid #aaa;
+  padding: 0.5em 0 0.5em 2em;
+}

--- a/src/components/user/user-missions.css
+++ b/src/components/user/user-missions.css
@@ -3,6 +3,7 @@
   flex-wrap: wrap;
   width: 45%;
 }
+
 .user-missions-title {
   font-size: 1.5em;
   font-weight: 600;

--- a/src/components/user/user-missions.js
+++ b/src/components/user/user-missions.js
@@ -1,0 +1,13 @@
+import PropTypes from 'prop-types';
+
+const UserMissions = ({ name }) => (
+  <li className="user-missions-li">
+    <p>{name}</p>
+  </li>
+);
+
+UserMissions.propTypes = {
+  name: PropTypes.string.isRequired,
+};
+
+export default UserMissions;

--- a/src/pages/user.js
+++ b/src/pages/user.js
@@ -1,7 +1,29 @@
-const User = () => (
-  <>
-    <p>User</p>
-  </>
-);
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux/es/exports';
+import UserMissions from '../components/user/user-missions';
+import { userMissionsAction } from '../redux/user/user';
+import '../components/user/user-missions.css';
+
+const User = () => {
+  const userData = useSelector((state) => state.user);
+  const missionsData = useSelector((state) => state.missions);
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(userMissionsAction(missionsData));
+  }, []);
+  return (
+    <>
+      <ul className="user-missions-ul">
+        <div className="user-missions-title"> My Missions</div>
+        {userData.missions.map((mission) => (
+          <UserMissions
+            key={mission.mission_id}
+            name={mission.mission_name}
+          />
+        ))}
+      </ul>
+    </>
+  );
+};
 
 export default User;

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -2,11 +2,13 @@ import { configureStore, applyMiddleware } from '@reduxjs/toolkit';
 import thunk from 'redux-thunk';
 import rockets from './rockets/fetchRockets';
 import missionsReducer from './missions/missions';
+import userReducer from './user/user';
 
 const storeReducer = configureStore({
   reducer: {
     rockets,
     missions: missionsReducer,
+    user: userReducer,
   },
 }, applyMiddleware(thunk));
 

--- a/src/redux/user/user.js
+++ b/src/redux/user/user.js
@@ -1,0 +1,25 @@
+const USER_MISSIONS = 'space-thub/misssions/USER_MISSIONS';
+
+export const userMissionsAction = (data) => ({
+  type: USER_MISSIONS,
+  payload: data,
+});
+
+const initialState = {
+  missions: [],
+  rockets: [],
+};
+
+const userReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case USER_MISSIONS:
+      return {
+        ...state,
+        missions: action.payload.filter((mission) => mission.reserved === true),
+      };
+    default:
+      return state;
+  }
+};
+
+export default userReducer;


### PR DESCRIPTION
On this pull request, I will be adding the missions that the user joined on the My Profile page

## Summary

- [x] Change text when a user joins a mission.
- [x] Create a new file to work with the states without changing the previous states.
- [x] Filter all the missions pages to work with only the missions that the user selected.
![the-wolf-of-wall-street-clap](https://user-images.githubusercontent.com/98921366/186487249-8b4e0b90-6f31-41d7-ab06-920b7cd3e994.gif)
